### PR TITLE
Fix collection export

### DIFF
--- a/src/nendo/library/sqlalchemy_library.py
+++ b/src/nendo/library/sqlalchemy_library.py
@@ -2155,14 +2155,16 @@ class SqlAlchemyNendoLibrary(schema.NendoLibraryPlugin):
         collection_tracks = self.get_collection_tracks(collection_id)
         now = datetime.now().strftime("%Y%m%d%H%M%S") # noqa: DTZ005
         if not os.path.isdir(export_path):
-            logger.error(f"export_path {export_path} is not a valid directory!")
-            return []
+            logger.info(
+                f"Export path {export_path} does not exist, creating now.",
+            )
+            os.makedirs(export_path, exist_ok=True)
         track_file_paths = []
         for track in collection_tracks:
             if track.has_meta("original_filename"):
                 original_filename = track.get_meta("original_filename")
             else:
-                original_filename = track.get_meta("file_name")
+                original_filename = track.resource.file_name
             file_name = f"{original_filename}_{filename_suffix}_{now}.{file_format}"
             file_path = os.path.join(export_path, file_name)
             track_file_path = self.export_track(

--- a/src/nendo/schema/core.py
+++ b/src/nendo/schema/core.py
@@ -1661,7 +1661,7 @@ class NendoStorageLocalFS(NendoStorage):
     def init_storage_for_user(self, user_id: str) -> str:  # noqa: ARG002
         """Initialize local storage for user."""
         if not os.path.isdir(self.library_path):
-            logger.warning(
+            logger.info(
                 f"Library path {self.library_path} does not exist, creating now.",
             )
             os.makedirs(self.library_path)


### PR DESCRIPTION
This PR fixes two small issues in the `SqlAlchemyNendoLibrary.export_collection()` function:

- If the export directory does not exist, nendo will create it now instead of failing with an error
- A bug was fixed where the `file_name` access was wrong