### PR TITLE
fix: filter_tracks access track_type bug

### DIFF
--- a/src/nendo/library/sqlalchemy_library.py
+++ b/src/nendo/library/sqlalchemy_library.py
@@ -1200,7 +1200,7 @@ class SqlAlchemyNendoLibrary(schema.NendoLibraryPlugin):
             # apply track type filter if applicable
             if track_type is not None:
                 if isinstance(track_type, list):
-                    query = query.filter(model.NendoTrackDB.value.in_(track_type))
+                    query = query.filter(model.NendoTrackDB.track_type.in_(track_type))
                 else:
                     query = query.filter(model.NendoTrackDB.track_type == track_type)
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -169,6 +169,8 @@ class DefaultLibraryTests(unittest.TestCase):
         result = nd.library.filter_tracks(track_type="stem")
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].id, test_track_1.id)
+        result = nd.library.filter_tracks(track_type=["stem", "track"])
+        self.assertEqual(len(result), 2)
 
     def test_get_tracks_filtered_by_collection(self):
         """Test filtering of tracks by collection."""


### PR DESCRIPTION
This PR fixes a small bug in the `SqlAlchemyNendoLibrary.filter_tracks()` method and adjusts the corresponding test to also cover that line.