### PR TITLE
Fix: make plugin_version optional when adding plugin data

### DIFF
--- a/src/nendo/library/sqlalchemy_library.py
+++ b/src/nendo/library/sqlalchemy_library.py
@@ -917,10 +917,10 @@ class SqlAlchemyNendoLibrary(schema.NendoLibraryPlugin):
     def add_plugin_data(
         self,
         track_id: Union[str, uuid.UUID],
-        plugin_name: str,
-        plugin_version: str,
         key: str,
         value: Any,
+        plugin_name: str,
+        plugin_version: Optional[str] = None,
         user_id: Optional[Union[str, uuid.UUID]] = None,
         replace: bool = False,
     ) -> schema.NendoPluginData:
@@ -929,10 +929,12 @@ class SqlAlchemyNendoLibrary(schema.NendoLibraryPlugin):
         Args:
             track_id (Union[str, UUID]): ID of the track to which
                 the plugin data should be added.
-            plugin_name (str): Name of the plugin.
-            plugin_version (str): Version of the plugin.
             key (str): Key under which to save the data.
             value (Any): Data to save.
+            plugin_name (str): Name of the plugin.
+            plugin_version (str, optional): Version of the plugin. If not specified,
+                the currently loaded version of the plugin given by `plugin_name`
+                will be used.
             user_id (Union[str, UUID], optional): ID of user adding the plugin data.
             replace (bool, optional): Flag that determines whether
                 the last existing data point for the given plugin name and -version
@@ -944,6 +946,9 @@ class SqlAlchemyNendoLibrary(schema.NendoLibraryPlugin):
         # create plugin data
         user_id = self._ensure_user_uuid(user_id)
         value_converted = self._convert_plugin_data(value=value, user_id=user_id)
+        if plugin_version is None:
+            plugin = getattr(self.nendo_instance.plugins, plugin_name)
+            plugin_version = plugin.version
         plugin_data = schema.NendoPluginDataCreate(
             track_id=ensure_uuid(track_id),
             user_id=ensure_uuid(user_id),

--- a/src/nendo/library/sqlalchemy_library.py
+++ b/src/nendo/library/sqlalchemy_library.py
@@ -932,7 +932,7 @@ class SqlAlchemyNendoLibrary(schema.NendoLibraryPlugin):
             key (str): Key under which to save the data.
             value (Any): Data to save.
             plugin_name (str): Name of the plugin.
-            plugin_version (str, optional): Version of the plugin. If not specified,
+            plugin_version (str, optional): Version of the plugin. If none is given,
                 the currently loaded version of the plugin given by `plugin_name`
                 will be used.
             user_id (Union[str, UUID], optional): ID of user adding the plugin data.
@@ -947,7 +947,14 @@ class SqlAlchemyNendoLibrary(schema.NendoLibraryPlugin):
         user_id = self._ensure_user_uuid(user_id)
         value_converted = self._convert_plugin_data(value=value, user_id=user_id)
         if plugin_version is None:
-            plugin = getattr(self.nendo_instance.plugins, plugin_name)
+            try:
+                plugin = getattr(self.nendo_instance.plugins, plugin_name)
+            except AttributeError as e:
+                self.logger.error(
+                    f"Plugin with name {plugin_name} is not loaded. "
+                    "You have to manually specify the plugin_version parameter.",
+                )
+                return None
             plugin_version = plugin.version
         plugin_data = schema.NendoPluginDataCreate(
             track_id=ensure_uuid(track_id),

--- a/src/nendo/schema/core.py
+++ b/src/nendo/schema/core.py
@@ -515,20 +515,22 @@ class NendoTrack(NendoTrackBase):
 
     def add_plugin_data(
         self,
-        plugin_name: str,
-        plugin_version: str,
         key: str,
         value: str,
+        plugin_name: str,
+        plugin_version: Optional[str] = None,
         user_id: Optional[Union[str, uuid.UUID]] = None,
         replace: bool = True,
     ) -> NendoTrack:
         """Add plugin data to a NendoTrack and persist changes into the DB.
 
         Args:
-            plugin_name (str): Name of the plugin.
-            plugin_version (str): Version of the plugin.
             key (str): Key under which to save the data.
             value (Any): Data to save.
+            plugin_name (str): Name of the plugin.
+            plugin_version (str): Version of the plugin. If none is given,
+                the currently loaded version of the plugin given by `plugin_name`
+                will be used.
             user_id (Union[str, UUID], optional): ID of user adding the plugin data.
             replace (bool, optional): Flag that determines whether
                 the last existing data point for the given plugin name and -version

--- a/tests/test_plugin_data.py
+++ b/tests/test_plugin_data.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from nendo import Nendo, NendoConfig, NendoPluginData
+from nendo import Nendo, NendoConfig, NendoPlugin, NendoPluginData
 
 nd = Nendo(
     config=NendoConfig(
@@ -36,6 +36,46 @@ class PluginDataTest(unittest.TestCase):
         track = nd.library.get_track(track_id=track.id)
         self.assertEqual(len(track.plugin_data), 1)
         self.assertEqual(track.plugin_data[0], pd)
+
+    def test_add_plugin_data_without_version(self):
+        """Test the adding of plugin data to a `NendoTrack`."""
+        nd.library.reset(force=True)
+        my_plugin = NendoPlugin(
+            nendo_instance=nd,
+            config=nd.config,
+            logger=nd.logger,
+            plugin_name="test_plugin",
+            plugin_version="1.0",
+        )
+        nd.plugins.add(
+            plugin_name="test_plugin",
+            version="1.0",
+            plugin_instance=my_plugin,
+        )
+        track = nd.library.add_track(file_path="tests/assets/test.mp3")
+        _ = nd.library.add_plugin_data(
+            track_id=track.id,
+            plugin_name="test_plugin",
+            key="test",
+            value="value",
+        )
+        track = nd.library.get_track(track_id=track.id)
+        self.assertEqual(len(track.plugin_data), 1)
+        self.assertEqual(track.plugin_data[0].plugin_version, "1.0")
+
+    def test_add_plugin_data_without_version_fails(self):
+        """Test the adding of plugin data to a `NendoTrack`."""
+        nd.library.reset(force=True)
+        track = nd.library.add_track(file_path="tests/assets/test.mp3")
+        pd = nd.library.add_plugin_data(
+            track_id=track.id,
+            plugin_name="test_plugin_2",
+            key="test",
+            value="value",
+        )
+        track = nd.library.get_track(track_id=track.id)
+        self.assertEqual(pd, None)
+        self.assertEqual(len(track.plugin_data), 0)
 
     def test_get_plugin_data(self):
         """Test the getting of plugin data from a `NendoTrack`."""


### PR DESCRIPTION
This PR introduces a small fix that makes the `plugin_version` argument optional when adding plugin data directly to a track or via the library. If the `plugin_version` is not specified, the library will determine it automatically via the plugin registry.